### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,6 +15,10 @@ module.exports = {
     dest:"./dist",
     description: "Make development easier",
     themeConfig: {
+        algolia: {
+          apiKey: 'a1d16f60a5b8bbe85fe2d92cb852bc62',
+          indexName: 'jexia'
+        },
         logo: '/logo-decorated.svg',
         smoothScroll: false,
         displayAllHeaders: false,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.