### PR TITLE
Refresh tokens

### DIFF
--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -229,3 +229,13 @@ Result: User A will have full access to Orders dataset as Policy 2 is subset of 
 ::: tip
 You can create as many policies as you need. All of them will be evaluated during the request. Changes in a policy have an immediate effect. 
 :::
+
+## Refreshing Tokens
+
+Refreshing a token requires the API Key and API Secret to be used to receive an access token and a refresh token. This can be done as seen [above](#api-keys). Once this first call has been made, the API Secret is no longer needed to refresh the current token. If the token is not refreshed after a 2 hour period, a new request to the `/auth` endpoint will be needed, and you will receive a new access token and refresh token.
+
+::: tip
+At this moment in time, the JavaScript SDK automatically refreshes the token, however, other SDKs do not. You will need to do this manually.
+:::
+
+To view all of the endpoints, errors they return and example uses, please see the [Management Contracts](/mgm) page where a swagger view is available.


### PR DESCRIPTION
This includes a small section on how to refresh a token and a notice on the SDKs that currently do and do not do this automatically.  I have also added a small paragraph linking to the Management Contracts explaining that you can find all the endpoints here. This is something I missed as I'm used to seeing it by other names, such as "API Endpoints" and I think this is therefore useful. 

Resolves #42.